### PR TITLE
feat: add UTM attribution params to store links

### DIFF
--- a/src/components/find-a-store.tsx
+++ b/src/components/find-a-store.tsx
@@ -49,6 +49,20 @@ const shuffleArray = (arr: Array<any>): Array<any> => {
 const isOfficialStore = (store: StoreRegion["stores"][number]) =>
   Boolean(store.official || store.url.includes("typeractive.xyz"));
 
+const addAttributionParams = (url: string): string => {
+  try {
+    const urlObj = new URL(url);
+    urlObj.searchParams.set("utm_source", "nicekeyboards");
+    urlObj.searchParams.set("utm_medium", "referral");
+    urlObj.searchParams.set("utm_campaign", "find-a-store");
+    return urlObj.toString();
+  } catch {
+    // If URL parsing fails, append params manually
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}utm_source=nicekeyboards&utm_medium=referral&utm_campaign=find-a-store`;
+  }
+};
+
 export default function FindAStore({ stores }: { stores: StoreRegion[] }) {
   const [storesState, setStoresState] = useState(stores);
   const [stock, setStock] = useState<{ [url: string]: boolean | undefined }>({});
@@ -248,7 +262,7 @@ export default function FindAStore({ stores }: { stores: StoreRegion[] }) {
               return (
                 <Link
                   target="_blank"
-                  href={store.url}
+                  href={addAttributionParams(store.url)}
                   rel="noopener"
                   py="0.5rem"
                   px="1rem"


### PR DESCRIPTION
## Summary
Adds UTM tracking parameters to all outbound store links in the Find a Store component.

## Changes
- Added `addAttributionParams()` helper function that appends:
  - `utm_source=nicekeyboards`
  - `utm_medium=referral`
  - `utm_campaign=find-a-store`
- Applied to all store links in the component

## Why
This enables tracking referred sessions to partner stores (like Typeractive) via standard UTM parameters. Previously there was no way to see which sales came from nicekeyboards.com referrals.

## Testing
The function handles both:
- Standard URLs (uses URL API to properly append params)
- Edge cases (fallback to string concatenation if URL parsing fails)