### PR TITLE
Fix referrer policy for store attribution

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Problem
The site currently sends `Referrer-Policy: same-origin` (set by gatsby-plugin-netlify defaults), which tells browsers to strip the referrer header on cross-origin navigation.

This means when users click store links (like typeractive.xyz), Shopify analytics shows a blank referrer — making it impossible to attribute traffic to nicekeyboards.com.

## Solution
Add a `netlify.toml` that sets `Referrer-Policy: strict-origin-when-cross-origin` — the modern browser default. This sends the origin (`https://nicekeyboards.com`) on cross-site clicks while still being privacy-conscious.

## Testing
After deploy, click a store link and verify the referrer shows up in the destination site's analytics (or check via browser devtools Network tab).